### PR TITLE
Give the form a real submit button

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -220,6 +220,10 @@ footer a {
     display: none;
 }
 
+#submit-button {
+    display: none;
+}
+
 #date-picker {
     width: auto;
     justify-content: center;

--- a/assets/html/form.html
+++ b/assets/html/form.html
@@ -10,8 +10,12 @@
         {{ end }}
         input from:#trigger-submit,
         input delay:1s from:#input-url,
-        change from:#input-mrg"
+        change from:#input-mrg,
+        click from:#submit-button"
         >
+    <!-- This submit button prevents other buttons in the form from being
+     treated as the sbubmit button -->
+    <input type="submit" id="submit-button" value="Submit"></input>
     <div class="input-group">
         <input id="input-url"
             type="text"


### PR DESCRIPTION
This prevents other buttons in the form from being treated as the submit button and fixes a bug where, because the first matcher's delete button was the first button in the form; pressing return in any text box triggered it and deleted the frist matcher.

Fixes #7 